### PR TITLE
feat: add notion articles on home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,16 @@
-import { getNotionPages } from "@/lib/notion/notion";
+import { getArticles } from "@/lib/notion/notion";
 import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 
 export default async function Home() {
-  const posts = await getNotionPages({ pageSize: 10 });
+  const articles = await getArticles({ pageSize: 10 });
 
   return (
     <div className="min-h-screen p-2 pb-20 gap-16 sm:p-10 font-[family-name:var(--font-geist-sans)]">
@@ -11,19 +19,24 @@ export default async function Home() {
           Франция | Гайд по иммиграции и интеграции
         </h1>
 
-        <div className="space-y-4">
-          {posts.map((post) => (
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {articles.map((article) => (
             <Link
-              key={post.id}
-              href={`/posts/${post.properties.URL.url}`}
-              className="block p-6 border rounded hover:bg-gray-50"
+              key={article.id}
+              href={`/posts/${article.slug}`}
+              className="block hover:no-underline"
             >
-              <h2 className="text-xl font-semibold">
-                {post.properties.Page.title[0].plain_text}
-              </h2>
-              <p className="text-gray-600 mt-2">
-                {new Date(post.created_time).toLocaleDateString()}
-              </p>
+              <Card className="transition-border hover:shadow-md">
+                <CardHeader>
+                  <CardTitle>{article.title}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <CardDescription>{article.description}</CardDescription>
+                </CardContent>
+                <CardFooter>
+                  {new Date(article.publishedAt).toLocaleDateString()}
+                </CardFooter>
+              </Card>
             </Link>
           ))}
         </div>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,76 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-xl border bg-card text-card-foreground shadow",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/src/lib/notion/mapper.ts
+++ b/src/lib/notion/mapper.ts
@@ -1,0 +1,11 @@
+import { NotionPage } from "./schemas";
+
+export function mapNotionPageToArticle(page: NotionPage): Article {
+  return {
+    id: page.id,
+    title: page.properties.Page.title[0]?.plain_text || "",
+    description: page.properties.Description.rich_text[0]?.plain_text || "",
+    slug: page.properties.URL.url,
+    publishedAt: new Date(page.properties["Publish date"]?.date?.start || ""),
+  };
+}

--- a/src/lib/notion/schemas.ts
+++ b/src/lib/notion/schemas.ts
@@ -16,7 +16,7 @@ const multiSelectOptionSchema = z.object({
   color: z.string(),
 });
 
-const titleTextSchema = z.object({
+const textSchema = z.object({
   type: z.string(),
   text: z
     .object({
@@ -78,7 +78,12 @@ const pagePropertiesSchema = z.object({
   Page: z.object({
     id: z.literal("title"),
     type: z.literal("title"),
-    title: z.array(titleTextSchema),
+    title: z.array(textSchema),
+  }),
+  Description: z.object({
+    id: z.string(),
+    type: z.literal("rich_text"),
+    rich_text: z.array(textSchema),
   }),
   Owner: z.object({
     id: z.string(),

--- a/src/lib/notion/types.ts
+++ b/src/lib/notion/types.ts
@@ -1,0 +1,7 @@
+type Article = {
+  id: string;
+  title: string;
+  description: string;
+  slug: string;
+  publishedAt: Date;
+};


### PR DESCRIPTION
## Context
For this PR I want to introduce the usage of notion articles on the Home page. As part of this PR I also simplified entities from notion to use on frontend only what we needed.

## Changes
- Added Card component
- Show articles on Home page
- Added additional fields to the notion page
- Added mapper to simplify entities on frontend

## How to test
Note: for testing you need NOTION_API_TOKEN

- Open home page
Result: You should see only published articles

Note: Some of articles don't have title because we need to update notion DB